### PR TITLE
Refactoring of exceptions and some other simplifications

### DIFF
--- a/src/main/java/co/alphavantage/AlphaVantageConnector.java
+++ b/src/main/java/co/alphavantage/AlphaVantageConnector.java
@@ -24,7 +24,7 @@ public class AlphaVantageConnector implements ApiConnector {
   }
 
   @Override
-  public String getRequest(ApiParameter... apiParameters) throws AlphaVantageException {
+  public String getRequest(ApiParameter... apiParameters) {
     String params = getParameters(apiParameters);
     try {
       URL request = new URL(BASE_URL + params);

--- a/src/main/java/co/alphavantage/ApiConnector.java
+++ b/src/main/java/co/alphavantage/ApiConnector.java
@@ -1,7 +1,6 @@
 package co.alphavantage;
 
 import co.alphavantage.input.ApiParameter;
-import co.alphavantage.output.AlphaVantageException;
 
 /**
  * Connection to api endpoint.
@@ -11,7 +10,7 @@ public interface ApiConnector {
   /**
    * Sends request to api
    * @param apiParameters the api parameters (required/optional) to the api call
-   * @return Either the raw Json string or IOExcpetion
+   * @return Either the raw Json string
    */
-  String getRequest(ApiParameter... apiParameters) throws AlphaVantageException;
+  String getRequest(ApiParameter... apiParameters);
 }

--- a/src/main/java/co/alphavantage/TechnicalIndicators.java
+++ b/src/main/java/co/alphavantage/TechnicalIndicators.java
@@ -5,7 +5,6 @@ import co.alphavantage.input.technicalindicator.Function;
 import co.alphavantage.input.technicalindicator.Interval;
 import co.alphavantage.input.technicalindicator.SeriesType;
 import co.alphavantage.input.technicalindicator.TimePeriod;
-import co.alphavantage.output.AlphaVantageException;
 import co.alphavantage.output.technicalindicators.SMA;
 
 /**
@@ -21,7 +20,7 @@ public class TechnicalIndicators {
     this.apiConnector = apiConnector;
   }
 
-  public SMA sma(String symbol, Interval interval, TimePeriod timePeriod, SeriesType seriesType) throws AlphaVantageException{
+  public SMA sma(String symbol, Interval interval, TimePeriod timePeriod, SeriesType seriesType) {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.SMA, timePeriod, interval, seriesType);
     return SMA.from(json);
   }

--- a/src/main/java/co/alphavantage/TimeSeries.java
+++ b/src/main/java/co/alphavantage/TimeSeries.java
@@ -4,7 +4,6 @@ import co.alphavantage.input.Symbol;
 import co.alphavantage.input.timeseries.Function;
 import co.alphavantage.input.timeseries.Interval;
 import co.alphavantage.input.timeseries.OutputSize;
-import co.alphavantage.output.AlphaVantageException;
 import co.alphavantage.output.JsonParser;
 import co.alphavantage.output.timeseries.*;
 
@@ -29,7 +28,7 @@ public class TimeSeries {
    * @param outputSize the specification of the amount of returned data points {@link OutputSize}
    * @return either a successful response (left) or an exception (right)
    */
-  public IntraDay intraDay(String symbol, Interval interval, OutputSize outputSize) throws AlphaVantageException {
+  public IntraDay intraDay(String symbol, Interval interval, OutputSize outputSize)  {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.INTRADAY, interval, outputSize);
     return IntraDay.from(interval, json);
   }
@@ -39,7 +38,7 @@ public class TimeSeries {
    * @param interval the interval between two consecutive data points in the time series {@link Interval}
    * @return either a successful response (left) or an exception (right)
    */
-  public IntraDay intraDay(String symbol, Interval interval) throws AlphaVantageException {
+  public IntraDay intraDay(String symbol, Interval interval)  {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.INTRADAY, interval);
     return IntraDay.from(interval, json);
   }
@@ -49,7 +48,7 @@ public class TimeSeries {
    * @param outputSize the specification of the amount of returned data points {@link OutputSize}
    * @return either a successful response (left) or an exception (right)
    */
-  public Daily daily(String symbol, OutputSize outputSize) throws AlphaVantageException {
+  public Daily daily(String symbol, OutputSize outputSize)  {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.DAILY, outputSize);
     return Daily.from(json);
   }
@@ -58,7 +57,7 @@ public class TimeSeries {
    * @param symbol the stock symbol to lookup
    * @return either a successful response (left) or an exception (right)
    */
-  public Daily daily(String symbol) throws AlphaVantageException {
+  public Daily daily(String symbol) {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.DAILY);
     return Daily.from(json);
   }
@@ -68,7 +67,7 @@ public class TimeSeries {
    * @param outputSize the specification of the amount of returned data points {@link OutputSize}
    * @return either a successful response (left) or an exception (right)
    */
-  public DailyAdjusted dailyAdjusted(String symbol, OutputSize outputSize) throws AlphaVantageException{
+  public DailyAdjusted dailyAdjusted(String symbol, OutputSize outputSize) {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.DAILY_ADJUSTED, outputSize);
     return DailyAdjusted.from(json);
   }
@@ -77,7 +76,7 @@ public class TimeSeries {
    * @param symbol the stock symbol to lookup
    * @return either a successful response (left) or an exception (right)
    */
-  public DailyAdjusted dailyAdjusted(String symbol) throws AlphaVantageException {
+  public DailyAdjusted dailyAdjusted(String symbol)  {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.DAILY_ADJUSTED);
     return DailyAdjusted.from(json);
   }
@@ -86,7 +85,7 @@ public class TimeSeries {
    * @param symbol the stock symbol to lookup
    * @return either a successful response (left) or an exception (right)
    */
-  public Weekly weekly(String symbol) throws AlphaVantageException {
+  public Weekly weekly(String symbol)  {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.WEEKLY);
     return Weekly.from(json);
   }
@@ -95,7 +94,7 @@ public class TimeSeries {
    * @param symbol the stock symbol to lookup
    * @return either a successful response (left) or an exception (right)
    */
-  public WeeklyAdjusted weeklyAdjusted(String symbol) throws AlphaVantageException {
+  public WeeklyAdjusted weeklyAdjusted(String symbol)  {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.WEEKLY_ADJUSTED);
     return WeeklyAdjusted.from(json);
   }
@@ -104,7 +103,7 @@ public class TimeSeries {
    * @param symbol the stock symbol to lookup
    * @return either a successful response (left) or an exception (right)
    */
-  public Monthly monthly(String symbol) throws AlphaVantageException {
+  public Monthly monthly(String symbol)  {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.MONTHLY);
     return Monthly.from(json);
   }
@@ -113,7 +112,7 @@ public class TimeSeries {
    * @param symbol the stock symbol to lookup
    * @return either a successful response (left) or an exception (right)
    */
-  public MonthlyAdjusted monthlyAdjusted(String symbol) throws AlphaVantageException {
+  public MonthlyAdjusted monthlyAdjusted(String symbol)  {
     String json = apiConnector.getRequest(new Symbol(symbol), Function.MONTHLY_ADJUSTED);
     return MonthlyAdjusted.from(json);
   }

--- a/src/main/java/co/alphavantage/output/AlphaVantageException.java
+++ b/src/main/java/co/alphavantage/output/AlphaVantageException.java
@@ -1,6 +1,6 @@
 package co.alphavantage.output;
 
-public class AlphaVantageException extends Exception {
+public class AlphaVantageException extends RuntimeException {
   public AlphaVantageException(String message, Exception e) {
     super(message, e);
   }

--- a/src/main/java/co/alphavantage/output/JsonParser.java
+++ b/src/main/java/co/alphavantage/output/JsonParser.java
@@ -15,9 +15,9 @@ public abstract class JsonParser<Data> {
   private static com.google.gson.JsonParser PARSER = new com.google.gson.JsonParser();
   protected static Gson GSON = new Gson();
 
-  public abstract Data resolve(JsonObject rootObject) throws AlphaVantageException;
+  public abstract Data resolve(JsonObject rootObject);
 
-  public Data parseJson(String json) throws AlphaVantageException {
+  public Data parseJson(String json) {
     try {
       JsonElement jsonElement = PARSER.parse(json);
       JsonObject rootObject = jsonElement.getAsJsonObject();

--- a/src/main/java/co/alphavantage/output/technicalindicators/SMA.java
+++ b/src/main/java/co/alphavantage/output/technicalindicators/SMA.java
@@ -25,7 +25,7 @@ public class SMA {
     return indicatorData;
   }
 
-  public static SMA from(String json) throws AlphaVantageException {
+  public static SMA from(String json) {
     Parser parser = new Parser();
     return parser.parseJson(json);
   }
@@ -39,17 +39,21 @@ public class SMA {
 
     @Override
     SMA resolve(Map<String, String> metaData,
-                Map<String, Map<String, String>> indicatorData) throws AlphaVantageException {
+                Map<String, Map<String, String>> indicatorData) {
       List<SMAData> indicators = new ArrayList<>();
+      indicatorData.forEach((key, values) -> indicators.add(getSMAData(key, values)));
+      return new SMA(metaData, indicators);
+    }
+
+    private SMAData getSMAData(String key, Map<String, String> values) {
       try {
-        indicatorData.forEach((key, values) -> indicators.add(new SMAData(
+        return new SMAData(
                 DateTime.parse(key, DATE_WITH_SIMPLE_TIME_FORMAT),
                 Double.parseDouble(values.get("SMA"))
-        )));
+        );
       } catch (Exception e) {
         throw new AlphaVantageException("SMA adjusted api change", e);
       }
-      return new SMA(metaData, indicators);
     }
 
 

--- a/src/main/java/co/alphavantage/output/technicalindicators/TechnicalIndicatorParser.java
+++ b/src/main/java/co/alphavantage/output/technicalindicators/TechnicalIndicatorParser.java
@@ -12,12 +12,12 @@ import java.util.Map;
 public abstract class TechnicalIndicatorParser<Data> extends JsonParser<Data> {
 
   abstract Data resolve(Map<String, String> metaData,
-                        Map<String, Map<String, String>> indicatorData) throws AlphaVantageException;
+                        Map<String, Map<String, String>> indicatorData);
 
   abstract String getIndicatorKey();
 
   @Override
-  public Data resolve(JsonObject rootObject) throws AlphaVantageException {
+  public Data resolve(JsonObject rootObject) {
     Type metaDataType = new TypeToken<Map<String, String>>() {
     }.getType();
     Type dataType = new TypeToken<Map<String, Map<String, String>>>() {

--- a/src/main/java/co/alphavantage/output/timeseries/Daily.java
+++ b/src/main/java/co/alphavantage/output/timeseries/Daily.java
@@ -25,7 +25,7 @@ public class Daily {
     return stockData;
   }
 
-  public static Daily from(String json) throws AlphaVantageException {
+  public static Daily from(String json)  {
     Parser parser = new Parser();
     return parser.parseJson(json);
   }
@@ -39,7 +39,7 @@ public class Daily {
 
     @Override
     Daily resolve(Map<String, String> metaData,
-                  Map<String, Map<String, String>> stockData) throws AlphaVantageException {
+                  Map<String, Map<String, String>> stockData)  {
       List<StockData> stocks = new ArrayList<>();
       try {
         stockData.forEach((key, values) -> stocks.add(new StockData(

--- a/src/main/java/co/alphavantage/output/timeseries/DailyAdjusted.java
+++ b/src/main/java/co/alphavantage/output/timeseries/DailyAdjusted.java
@@ -26,7 +26,7 @@ public class DailyAdjusted {
     return stocks;
   }
 
-  public static DailyAdjusted from(String json) throws AlphaVantageException {
+  public static DailyAdjusted from(String json)  {
     Parser parser = new Parser();
     return parser.parseJson(json);
   }
@@ -40,7 +40,7 @@ public class DailyAdjusted {
 
     @Override
     DailyAdjusted resolve(Map<String, String> metaData,
-                          Map<String, Map<String, String>> stockData) throws AlphaVantageException {
+                          Map<String, Map<String, String>> stockData)  {
       List<StockData> stocks = new ArrayList<>();
       try {
         stockData.forEach((key, values) -> stocks.add(new StockData(

--- a/src/main/java/co/alphavantage/output/timeseries/IntraDay.java
+++ b/src/main/java/co/alphavantage/output/timeseries/IntraDay.java
@@ -26,7 +26,7 @@ public class IntraDay {
     return stocks;
   }
 
-  public static IntraDay from(Interval interval, String json) throws AlphaVantageException {
+  public static IntraDay from(Interval interval, String json)  {
     Parser parser = new Parser(interval);
     return parser.parseJson(json);
   }
@@ -45,7 +45,7 @@ public class IntraDay {
 
     @Override
     IntraDay resolve(Map<String, String> metaData,
-                     Map<String, Map<String, String>> stockData) throws AlphaVantageException {
+                     Map<String, Map<String, String>> stockData)  {
       List<StockData> stocks = new ArrayList<>();
       try {
         stockData.forEach((key, values) -> stocks.add(new StockData(

--- a/src/main/java/co/alphavantage/output/timeseries/Monthly.java
+++ b/src/main/java/co/alphavantage/output/timeseries/Monthly.java
@@ -26,7 +26,7 @@ public class Monthly {
     return stocks;
   }
 
-  public static Monthly from(String json) throws AlphaVantageException {
+  public static Monthly from(String json)  {
     Parser parser = new Parser();
     return parser.parseJson(json);
   }
@@ -40,7 +40,7 @@ public class Monthly {
 
     @Override
     Monthly resolve(Map<String, String> metaData,
-                    Map<String, Map<String, String>> stockData) throws AlphaVantageException {
+                    Map<String, Map<String, String>> stockData)  {
       List<StockData> stocks = new ArrayList<>();
       try {
         stockData.forEach((key, values) -> stocks.add(new StockData(

--- a/src/main/java/co/alphavantage/output/timeseries/MonthlyAdjusted.java
+++ b/src/main/java/co/alphavantage/output/timeseries/MonthlyAdjusted.java
@@ -26,7 +26,7 @@ public class MonthlyAdjusted {
     return stocks;
   }
 
-  public static MonthlyAdjusted from(String json) throws AlphaVantageException {
+  public static MonthlyAdjusted from(String json)  {
     Parser parser = new Parser();
     return parser.parseJson(json);  }
 
@@ -39,7 +39,7 @@ public class MonthlyAdjusted {
 
     @Override
     MonthlyAdjusted resolve(Map<String, String> metaData,
-                            Map<String, Map<String, String>> stockData) throws AlphaVantageException {
+                            Map<String, Map<String, String>> stockData)  {
       List<StockData> stocks = new ArrayList<>();
       try {
         stockData.forEach((key, values) -> stocks.add(new StockData(

--- a/src/main/java/co/alphavantage/output/timeseries/TimeSeriesParser.java
+++ b/src/main/java/co/alphavantage/output/timeseries/TimeSeriesParser.java
@@ -12,12 +12,12 @@ import java.util.Map;
 public abstract class TimeSeriesParser<Data> extends JsonParser<Data> {
 
   abstract Data resolve(Map<String, String> metaData,
-                        Map<String, Map<String, String>> stockData) throws AlphaVantageException;
+                        Map<String, Map<String, String>> stockData) ;
 
   abstract String getStockDataKey();
 
   @Override
-  public Data resolve(JsonObject rootObject) throws AlphaVantageException {
+  public Data resolve(JsonObject rootObject)  {
     Type metaDataType = new TypeToken<Map<String, String>>() {
     }.getType();
     Type dataType = new TypeToken<Map<String, Map<String, String>>>() {

--- a/src/main/java/co/alphavantage/output/timeseries/Weekly.java
+++ b/src/main/java/co/alphavantage/output/timeseries/Weekly.java
@@ -26,7 +26,7 @@ public class Weekly {
     return stocks;
   }
 
-  public static Weekly from(String json) throws AlphaVantageException {
+  public static Weekly from(String json)  {
     Parser parser = new Parser();
     return parser.parseJson(json);  }
 
@@ -40,7 +40,7 @@ public class Weekly {
 
     @Override
     Weekly resolve(Map<String, String> metaData,
-                   Map<String, Map<String, String>> stockData) throws AlphaVantageException {
+                   Map<String, Map<String, String>> stockData)  {
       List<StockData> stocks = new ArrayList<>();
       try {
         stockData.forEach((key, values) -> stocks.add(new StockData(

--- a/src/main/java/co/alphavantage/output/timeseries/WeeklyAdjusted.java
+++ b/src/main/java/co/alphavantage/output/timeseries/WeeklyAdjusted.java
@@ -26,7 +26,7 @@ public class WeeklyAdjusted {
     return stocks;
   }
 
-  public static WeeklyAdjusted from(String json) throws AlphaVantageException {
+  public static WeeklyAdjusted from(String json)  {
     Parser parser = new Parser();
     return parser.parseJson(json);
   }
@@ -40,7 +40,7 @@ public class WeeklyAdjusted {
 
     @Override
     WeeklyAdjusted resolve(Map<String, String> metaData,
-                           Map<String, Map<String, String>> stockData) throws AlphaVantageException {
+                           Map<String, Map<String, String>> stockData)  {
       List<StockData> stocks = new ArrayList<>();
       try {
         stockData.forEach((key, values) -> stocks.add(new StockData(

--- a/src/test/java/co/alphavantage/TimeSeriesTest.java
+++ b/src/test/java/co/alphavantage/TimeSeriesTest.java
@@ -19,7 +19,7 @@ public class TimeSeriesTest {
   private TimeSeries timeSeries;
 
   @Test(expected = AlphaVantageException.class)
-  public void changeOfAPI() throws AlphaVantageException {
+  public void changeOfAPI() {
     String unexpectedJson = "" +
             "{\n" +
             "    \"Meta Data\": {\n" +
@@ -42,14 +42,14 @@ public class TimeSeriesTest {
   }
 
   @Test(expected = AlphaVantageException.class)
-  public void nonExistingSymbol() throws AlphaVantageException {
+  public void nonExistingSymbol() {
     String json = "{\"Error Message\": \"Invalid API call. Please retry or visit the documentation (https://www.alphavantage.co/documentation/) for TIME_SERIES_INTRADAY.\"}";
     timeSeries = new TimeSeries(parameters -> json);
     timeSeries.intraDay("NONEXISTING", Interval.ONE_MIN, OutputSize.COMPACT);
   }
 
   @Test
-  public void intraDay() throws AlphaVantageException {
+  public void intraDay() {
     String json = "" +
             "{\n" +
             "    \"Meta Data\": {\n" +
@@ -109,7 +109,7 @@ public class TimeSeriesTest {
   }
 
   @Test
-  public void daily() throws AlphaVantageException {
+  public void daily() {
     String json = "" +
             "{\n" +
             "    \"Meta Data\": {\n" +
@@ -167,7 +167,7 @@ public class TimeSeriesTest {
   }
 
   @Test
-  public void dailyAdjusted() throws AlphaVantageException {
+  public void dailyAdjusted() {
     String json = "" +
             "{\n" +
             "    \"Meta Data\": {\n" +
@@ -237,7 +237,7 @@ public class TimeSeriesTest {
   }
 
   @Test
-  public void weekly() throws AlphaVantageException {
+  public void weekly() {
     String json = "" +
             "{\n" +
             "    \"Meta Data\": {\n" +
@@ -293,7 +293,7 @@ public class TimeSeriesTest {
   }
 
   @Test
-  public void weeklyAdjusted() throws AlphaVantageException {
+  public void weeklyAdjusted() {
     String json = "" +
             "{\n" +
             "    \"Meta Data\": {\n" +
@@ -357,7 +357,7 @@ public class TimeSeriesTest {
   }
 
   @Test
-  public void monthly() throws AlphaVantageException {
+  public void monthly() {
     String json = "" +
             "{\n" +
             "    \"Meta Data\": {\n" +
@@ -413,7 +413,7 @@ public class TimeSeriesTest {
   }
 
   @Test
-  public void monthlyAdjusted() throws AlphaVantageException {
+  public void monthlyAdjusted() {
     String json = "" +
             "{\n" +
             "    \"Meta Data\": {\n" +


### PR DESCRIPTION
To sumarize, by extending from RuntimeException you don't need to declare the throws in every method, as runtime exceptions are ment to be thrown without explicitly doing so.